### PR TITLE
port(issue-03): stop custom adventures crashing on quest goal pickup

### DIFF
--- a/INVNTORY.CPP
+++ b/INVNTORY.CPP
@@ -150,7 +150,11 @@ void PaintQuestItemFound(LONG MenuCombo,LONG b)
 
 	ITEMTYPE const QuestItem = ObjectList::mfGameTypetoItemType((THINGTYPE)GetQuestThing());
 	ItemType const &QuestItemData = ItemTypes[QuestItem];
-	strcpy(LongDesc, STRMGR_GetStr(QuestItemData.mfGetExtendedData()));
+	// items with no long description fall back to the short one
+	if (QuestItemData.mfGetExtendedData() != -1)
+		strcpy(LongDesc, STRMGR_GetStr(QuestItemData.mfGetExtendedData()));
+	else
+		strcpy(LongDesc, STRMGR_GetStr(QuestItemData.mfInfo()));
 
 	sprintf(Buf,FormatBuf,
 			    GAME_TTYPE::mfGetDescription((THINGTYPE)GetQuestThing()),
@@ -160,7 +164,11 @@ void PaintQuestItemFound(LONG MenuCombo,LONG b)
 	Y += gtext_height(Buf);
 	
 	strncpy(FormatBuf, STRMGR_GetStr(STR_QUESTITEM_YOUCANLEAVE), sizeof(FormatBuf));
-	sprintf(Buf, FormatBuf, place_names[SCENE_MGR::PlacesIndex]);
+	// user scenes aren't on the map, so name the adventure site instead
+	if (SCENE_MGR::PlacesIndex != -1)
+		sprintf(Buf, FormatBuf, place_names[SCENE_MGR::PlacesIndex]);
+	else
+		sprintf(Buf, FormatBuf, advsite[iAdventureSiteIndex].name);
 	gprint_text(X, Y, Buf, color);
 }
 	


### PR DESCRIPTION
Ported from birp-dev 55ae980.

PaintQuestItemFound() fed two out-of-range indices straight into lookups: ItemTypes entries with no ExtendedDataIdx pass -1 to STRMGR_GetStr (which indexes sOffsets[-1] and hands strcpy a wild pointer), and user scenes have advsite[].iPlaces == -1, so place_names[-1] is read out of bounds. Both now fall back - to the item's short MiscInfo string and to the adventure site name. Only the INVNTORY.CPP hunks were taken; the commit's CHANGELOG.md, README.txt and PVERSION.HXX changes are birp-dev bookkeeping.