### PR TITLE
port(issue-04): stop adventures, battles and missing art from crashin…

### DIFF
--- a/ADVENTUR.CPP
+++ b/ADVENTUR.CPP
@@ -142,7 +142,10 @@ void ADVENTURER::mfUpdateAdventureTeam(PLAYER const * const pPlayer )
 			if (SCENE_MGR::gTick > SoundDelay + fTimeLastBump)
 			{
 				fTimeLastBump = SCENE_MGR::gTick;
-				if (GAME_TTYPE::mfIsAvatarType(mythings[pPlayer->BumpIndex].type))
+				if (pPlayer->BumpIndex >= 0 &&
+					pPlayer->BumpIndex < MAX_THINGS &&
+					mythings[pPlayer->BumpIndex].valid == TRUE &&
+					GAME_TTYPE::mfIsAvatarType(mythings[pPlayer->BumpIndex].type))
 				{
 					if (CAvatar::mfDeadFlicSeq(pPlayer->BumpIndex))
 					{
@@ -208,6 +211,8 @@ void ADVENTURER::mfInitAdventureTeam(PLAYER const * const pPlayer)
 	fTimeLastBump = 0;
 	
 	fhdlPathPositions = NewBlock(sizeof(ADVENTURER_POSITION) * MAX_TRAIL_POINTS);
+	if (fhdlPathPositions == fERROR)
+		return;
 	DumbAutoLockArray<ADVENTURER_POSITION> const pPath(fhdlPathPositions);
 	
 	pPath[fFirstAdventurerIndex].mfUpdatePosition(pPlayer);
@@ -286,6 +291,8 @@ BOOL const ADVENTURER::mfIsAdventureTeam(CAvatar_pmfv pmfv)
 	     AdvItor++)
 	{
 		CAvatar const * const pAvatar = (CAvatar const * const) BLKPTR(*AdvItor);
+		if (!IsPointerGood(pAvatar))
+			continue;
 		if (TRUE == (pAvatar->*pmfv)())
 		{
 			Result = TRUE;
@@ -310,7 +317,9 @@ SHORT const ADVENTURER::mfFirstAdventurerIs(CAvatar_pmfv pmfv)
 	     AdvItor++)
 	{
 		CAvatar const * const pAvatar = (CAvatar const * const) BLKPTR(*AdvItor);
-		
+		if (!IsPointerGood(pAvatar))
+			continue;
+
 		if (TRUE == (pAvatar->*pmfv)())
 		{
 			Result = *AdvItor;
@@ -364,6 +373,11 @@ BOOL const ADVENTURER::mfJoinAdventureTeam(SHORT const hdlAvatar)
 {
 	BOOL Result = FALSE;
 	
+	// Without the path array mfGetMyPosition leaves the position untouched,
+	// so the avatar would be moved to garbage coordinates.
+	if (fhdlPathPositions == fERROR)
+		return FALSE;
+
 	if (hdlAvatar != fERROR)
 	{
 		SBYTE i;
@@ -377,7 +391,9 @@ BOOL const ADVENTURER::mfJoinAdventureTeam(SHORT const hdlAvatar)
 				LONG NewA;
 				
 				CAvatar * const pAvatar = (CAvatar * const) BLKPTR(hdlAvatar);
-				
+				if (!IsPointerGood(pAvatar))
+					break;
+
 				fhAvatar = hdlAvatar;
 				if (i == 0)
 				{
@@ -480,7 +496,9 @@ BOOL const ADVENTURER::mfDoesAdventureTeamHave(THINGTYPE const ThingType)
 	     AdvItor++)
 	{
 		CAvatar const * const  pAvatar = (CAvatar const * const) BLKPTR(*AdvItor);
-		
+		if (!IsPointerGood(pAvatar))
+			continue;
+
 		if (!pAvatar->mfAmIImmoblized() && pAvatar->hPlayerStats != fERROR)
 		{
 			DumbAutoLockPtr<PLAYER_STATS> const pPlayerStats(pAvatar->hPlayerStats);
@@ -509,6 +527,8 @@ void ADVENTURER::mfDoToAllAdventurers(CAvatar_pmf pmf)
 	     AdvItor++)
 	{
 		CAvatar * const  pAvatar = (CAvatar * const) BLKPTR(*AdvItor);
+		if (!IsPointerGood(pAvatar))
+			continue;
 		(pAvatar->*pmf)();
 	}
 }

--- a/AIBTLCAP.CPP
+++ b/AIBTLCAP.CPP
@@ -1511,9 +1511,12 @@ SHORT ResolveMissiles(CAvatar *pDefender)
 		)
 	{
 		CAvatar *pEnemy = (CAvatar *)BLKPTR(pDefender->hEnemy);
-		
+		if(!IsPointerGood(pEnemy))
+		{
+			pDefender->hEnemy = fERROR;
+		}
 		// if engaged with me, do no damage to myself
-		if(pEnemy->hEnemy != pDefender->hThis)
+		else if(pEnemy->hEnemy != pDefender->hThis)
 		{
 			if(pEnemy->hPlayerStats != fERROR)
 			{
@@ -1567,6 +1570,12 @@ SHORT DecodeBattleMagic( CAvatar * pAvatar )
 		{
 		case BTLCAP_MAGIC_NO_ATTACK:
 			pEnemy = (CAvatar *)BLKPTR(pAvatar->hEnemy);
+			if(!IsPointerGood(pEnemy))
+			{
+				pAvatar->hEnemy = fERROR;
+				retVal = BTL_N;
+				break;
+			}
 			// delay the enemy's next decision by 5 rounds
 			pEnemy->fBtlCap.ActionCount = 
 					5 * BattleTick + (BtlActionRate * SpeedLevel);
@@ -1720,8 +1729,12 @@ SHORT ResolveBattleMagic(CAvatar *pDefender)
 			if (pDefender->hEnemy != fERROR)
 			{
 				CAvatar *pAttacker = (CAvatar *)BLKPTR(pDefender->hEnemy);
+				if(!IsPointerGood(pAttacker))
+				{
+					pDefender->hEnemy = fERROR;
+				}
 				// check for resistance to all damage
-				if(pAttacker->hPlayerStats != fERROR)
+				else if(pAttacker->hPlayerStats != fERROR)
 				{
 					DumbAutoLockPtr<PLAYER_STATS const> const pPlayerStats(pAttacker->hPlayerStats);
 					
@@ -2184,15 +2197,16 @@ BOOL BATTLE_CAPTAIN_DATA::mfKillTroop(CAvatar *pAvatar, THINGTYPE KillType )
 	if(pTroop->hEnemy != fERROR)
 	{
 		CAvatar *pMyEnemy = (CAvatar *) BLKPTR(pTroop->hEnemy);
-		
-		if (pMyEnemy->fFollowBtlCap.hLeader != fERROR)
+		if (IsPointerGood(pMyEnemy) &&
+			pMyEnemy->fFollowBtlCap.hLeader != fERROR)
 		{
 			CAvatar *pEnemyLeader = 
 				(CAvatar *) BLKPTR((SHORT) pMyEnemy->fFollowBtlCap.hLeader);
 			
 			// GWP 5/18/97
 			// For all the troops attacking me, dis-enage me from them.
-			if (pEnemyLeader->fBtlCap.Leader.hdlSlotList != fERROR)
+			if (IsPointerGood(pEnemyLeader) &&
+				pEnemyLeader->fBtlCap.Leader.hdlSlotList != fERROR)
 			{
 				SHORT *pOtherList = (SHORT *)BLKPTR(pEnemyLeader->fBtlCap.Leader.hdlSlotList);
 				LONG k;
@@ -2201,7 +2215,8 @@ BOOL BATTLE_CAPTAIN_DATA::mfKillTroop(CAvatar *pAvatar, THINGTYPE KillType )
 					if (pOtherList[k] != fERROR)
 					{
 						CAvatar * pOtherTroop = (CAvatar *)BLKPTR(pOtherList[k]);
-						pOtherTroop->hEnemy = fERROR;
+						if (IsPointerGood(pOtherTroop))
+							pOtherTroop->hEnemy = fERROR;
 					}
 				}
 			}
@@ -3902,6 +3917,16 @@ void CAvatar::FollowBtlCap (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 		}
 		
 		pEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
+		if(!IsPointerGood(pEnemy))
+		{
+			pAvatar->hEnemy = fERROR;
+			pAvatar->Engaged--;
+			pAvatar->Status = AI_MOVING;
+			pAvatar->fTimeLastMoved = SCENE_MGR::gTick;
+			if (pAvatar->Engaged < 0)
+				pAvatar->Engaged = 0;
+			break;
+		}
 		
 		// if my enemy is dead, go back and stand in formation
 		if( pEnemy->Status == CAvatar::AI_DEAD )
@@ -4655,6 +4680,11 @@ void SendMagic ( CAvatar *pAvatar )
 		return;
 	
 	pEnemy = (CAvatar *)BLKPTR(pAvatar->hEnemy);
+	if(!IsPointerGood(pEnemy))
+	{
+		pAvatar->hEnemy = fERROR;
+		return;
+	}
 	
 	//----  if a remote player then send magic message to them
 

--- a/AIFIREBL.CPP
+++ b/AIFIREBL.CPP
@@ -441,7 +441,7 @@ void CAvatar::FireBall (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 								else
 								{
 									CAvatar * const pEnemy = (CAvatar * const) BLKPTR(pAvatar->hEnemy);
-									if (!SaveVs(pEnemy->hPlayerStats, ST_SPELL, 0))
+									if (pEnemy->hPlayerStats == fERROR || !SaveVs(pEnemy->hPlayerStats, ST_SPELL, 0))
 										pCastAvatar->mfInflictMagicDamage(pEnemy, pAvatar->mfType(), pAvatar->fDamage);
 									else	
 
@@ -492,7 +492,7 @@ void CAvatar::FireBall (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 							    pAvatar->mfType() == LORES_LIGHTNING_1)
 							{
 								CAvatar * const pEnemy = (CAvatar * const) BLKPTR(pCurrentScene->Avatars[i]);
-									if (!SaveVs(pEnemy->hPlayerStats, ST_SPELL, 0))
+									if (pEnemy->hPlayerStats == fERROR || !SaveVs(pEnemy->hPlayerStats, ST_SPELL, 0))
 										pCastAvatar->mfInflictMagicDamage(pEnemy, pAvatar->mfType(), pAvatar->fDamage);
 									else	
 										pCastAvatar->mfInflictMagicDamage(pEnemy, pAvatar->mfType(), pAvatar->fDamage/2);

--- a/AIFOLPLY.CPP
+++ b/AIFOLPLY.CPP
@@ -41,11 +41,14 @@ void FOLLOW_PLAYER_DATA::mfFollowPlayer()
 	if (fhAvatar != fERROR)
 	{
 		CAvatar const * const pAvatar = (CAvatar const * const) BLKPTR(fhAvatar);
-		SetPlayer(pAvatar->mfX(),
-		          pAvatar->mfY(),
-		          pAvatar->mfZ(),
-		          pAvatar->mfAngle(),
-		          0);
+		if (IsPointerGood(pAvatar))
+		{
+			SetPlayer(pAvatar->mfX(),
+			          pAvatar->mfY(),
+			          pAvatar->mfZ(),
+			          pAvatar->mfAngle(),
+			          0);
+		}
 	}
 }
 /* ========================================================================
@@ -135,9 +138,14 @@ void CAvatar::FollowPlayer (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 				{
 					
 					CAvatar * pEnemy = (CAvatar *) BLKPTR (pAvatar->hEnemy);
-				
-					pAvatar->FaceTo(pEnemy->mfX(), pEnemy->mfY());
-					
+					if (!IsPointerGood(pEnemy))
+					{
+						pAvatar->mfSethEnemy(fERROR);
+					}
+					else
+					{
+						pAvatar->FaceTo(pEnemy->mfX(), pEnemy->mfY());
+					}
 				}
 				
 				if (pAvatar->hPlayerStats == fERROR)
@@ -201,6 +209,12 @@ void CAvatar::FollowPlayer (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 				if (pAvatar->hEnemy != fERROR)
 				{
 					CAvatar *pAvatarEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
+					if (!IsPointerGood(pAvatarEnemy))
+					{
+						pAvatar->mfSethEnemy(fERROR);
+						pAvatar->Status = AI_SEARCH;
+						break;
+					}
 					const LONG distance = aprox_dist(pAvatar->mfX(),
 					                                 pAvatar->mfY(),
 					                                 pAvatarEnemy->mfX(),
@@ -314,7 +328,13 @@ void CAvatar::FollowPlayer (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 			if (pAvatar->hEnemy != fERROR)
 			{
 				CAvatar *pAvatarEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
-				
+				if (!IsPointerGood(pAvatarEnemy))
+				{
+					pAvatar->mfSethEnemy(fERROR);
+					pAvatar->Status = AI_SEARCH;
+					break;
+				}
+
 				if (pAvatarEnemy->mfAmIImmoblized())
 				{
 					pAvatar->Status = AI_SEARCH;
@@ -420,6 +440,11 @@ void CAvatar::FollowPlayer (CAvatar *pAvatar, CAvatar::AISTATUS Status)
 			if (pAvatar->hEnemy != fERROR)
 			{
 				CAvatar * const pAvatarEnemy = (CAvatar * const) BLKPTR(pAvatar->hEnemy);
+				if (!IsPointerGood(pAvatarEnemy))
+				{
+					pAvatar->mfSethEnemy(fERROR);
+					break;
+				}
 				const LONG distance = aprox_dist(pAvatar->mfX(),
 				                                 pAvatar->mfY(),
 				                                 pAvatarEnemy->mfX(),
@@ -468,7 +493,14 @@ Start_Attack:
 				if (pAvatar->hEnemy != fERROR)
 				{
 					CAvatar *pAvatarEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
-					pAvatarEnemy->mfEngage();
+					if (!IsPointerGood(pAvatarEnemy))
+					{
+						pAvatar->mfSethEnemy(fERROR);
+					}
+					else
+					{
+						pAvatarEnemy->mfEngage();
+					}
 				}
 				else
 				{
@@ -481,7 +513,13 @@ Start_Attack:
 			if (pAvatar->hEnemy != fERROR)
 			{
 				CAvatar *pAvatarEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
-				
+				if (!IsPointerGood(pAvatarEnemy))
+				{
+					pAvatar->mfSethEnemy(fERROR);
+					pAvatar->Status = AI_SEARCH;
+					break;
+				}
+
 				if (pAvatarEnemy->mfAmIImmoblized())
 				{
 					// Got'm
@@ -522,7 +560,15 @@ Start_Attack:
 						else
 						{
 							CAvatar const * const pAvatarEnemy = (CAvatar const * const) BLKPTR(pAvatar->hEnemy);
-							pAvatar->FaceTo(pAvatarEnemy->mfX(), pAvatarEnemy->mfY());
+							if (!IsPointerGood(pAvatarEnemy))
+							{
+								pAvatar->mfSethEnemy(fERROR);
+								pAvatar->Status = AI_SEARCH;
+							}
+							else
+							{
+								pAvatar->FaceTo(pAvatarEnemy->mfX(), pAvatarEnemy->mfY());
+							}
 						}
 						
 						if ((pAvatar->mfGetArtSequence() != ATTACK1SEQ &&
@@ -575,6 +621,12 @@ StartDefend:
 			if (pAvatar->hEnemy != fERROR)
 			{
 				CAvatar *pAvatarEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
+				if (!IsPointerGood(pAvatarEnemy))
+				{
+					pAvatar->mfSethEnemy(fERROR);
+					pAvatar->Status = AI_SEARCH;
+					break;
+				}
 				if (pAvatarEnemy->mfAmIImmoblized())
 				{
 					// Got'm

--- a/AVATAR.CPP
+++ b/AVATAR.CPP
@@ -1025,7 +1025,13 @@ BOOL CAvatar::mfWackEm(const HDL_AVATAR hEnemyTarget)
 	}
 	
 	CAvatar * const pEnemyTarget = (CAvatar * const) BLKPTR(hEnemyTarget);
-	
+	if (!IsPointerGood(pEnemyTarget))
+	{
+		mfSethEnemy(fERROR);
+		fDamageFlag = 0;
+		return FALSE;
+	}
+
 	if (pEnemyTarget->mfAmIImmoblized())
 	{
 		// Hey you're hitting a dead thing.
@@ -1321,7 +1327,12 @@ void CAvatar::mfFightSounds(HDL_AVATAR const hEnemyTarget)
 	}
 	
 	CAvatar * const pEnemyTarget = (CAvatar * const) BLKPTR(hEnemyTarget);
-	
+	if (!IsPointerGood(pEnemyTarget))
+	{
+		mfSethEnemy(fERROR);
+		return;
+	}
+
 	if (pEnemyTarget->mfAmIImmoblized())
 	{
 		// Hey you're hitting a dead thing.
@@ -2342,7 +2353,11 @@ LONG const CAvatar::mfCalculateAttackModifier( SHORT const hEnemyTarget) const
 	}
 	
 	CAvatar const * const pEnemyTarget = (CAvatar const * const) BLKPTR(hEnemyTarget);
-	
+	if (!IsPointerGood(pEnemyTarget))
+	{
+		return 0;
+	}
+
 	if (pEnemyTarget->hPlayerStats != fERROR && hPlayerStats != fERROR)
 	{
 		DumbAutoLockPtr<PLAYER_STATS const> const pAvatarStats(hPlayerStats);
@@ -2395,7 +2410,11 @@ LONG const CAvatar::mfToHitEnemy(SHORT const hEnemyTarget) const
 	}
 	
 	CAvatar * const pEnemyTarget = (CAvatar * const) BLKPTR(hEnemyTarget);
-	
+	if (!IsPointerGood(pEnemyTarget))
+	{
+		return 0;
+	}
+
 	if (pEnemyTarget->hPlayerStats != fERROR && hPlayerStats != fERROR)
 	{
 		DumbAutoLockPtr<PLAYER_STATS> const pAvatarStats(hPlayerStats);
@@ -2422,7 +2441,13 @@ void CAvatar::mfSetMyTurnToAttack()
 	if (hEnemy != fERROR)	// I have an enemy.
 	{
 		CAvatar * const pEnemy = (CAvatar * const) BLKPTR(hEnemy);
-		
+		if (!IsPointerGood(pEnemy))
+		{
+			hEnemy = fERROR;
+			mfClearTurnToAttack();
+			return;
+		}
+
 		// I am attacking and they're attacking me back.
 		if (Status == AI_ATTACK && pEnemy->hEnemy == hThis)
 		{
@@ -2488,6 +2513,12 @@ void CAvatar::mfDecideWhoseTurnToAttack()
 	    if (fAttackTurnFlag == ATTACK_TURN_NOT_DECIDED)
 	    {
 			CAvatar * const pEnemy = (CAvatar * const) BLKPTR(hEnemy);
+			if (!IsPointerGood(pEnemy))
+			{
+				hEnemy = fERROR;
+				mfClearTurnToAttack();
+				return;
+			}
 			if (pEnemy->hEnemy != hThis || pEnemy->Status != AI_ATTACK)
 			{
 				// If we are not paired off, I can hit any the time.
@@ -2558,26 +2589,36 @@ void CAvatar::mfStartNextFightSequence()
 			if (mfIsMyTurnToAttack() && hEnemy != fERROR)
 			{
 				CAvatar * const pEnemy = (CAvatar * const) BLKPTR(hEnemy);
-				if (pPlayerStats->mfGetCurHitPoints() > 3  ||
-				    pEnemy->hEnemy != hThis)
+				if (!IsPointerGood(pEnemy))
 				{
+					hEnemy = fERROR;
 					mfSetAttackMode(fFightSeq.mfGetNextSequence(mfType()));
+					mfSetAttackSequence(mfGetAttackMode());
+					mfClearTurnToAttack();
 				}
 				else
 				{
-					// Try to survive but still get in some hits.
-					// This is only an advantage if we are paired off.
-					if (random(2) == 0)
+					if (pPlayerStats->mfGetCurHitPoints() > 3  ||
+					    pEnemy->hEnemy != hThis)
 					{
 						mfSetAttackMode(fFightSeq.mfGetNextSequence(mfType()));
 					}
 					else
 					{
-						mfSetAttackMode(FIGHT_SEQUENCE::ATM_DEFEND);
+						// Try to survive but still get in some hits.
+						// This is only an advantage if we are paired off.
+						if (random(2) == 0)
+						{
+							mfSetAttackMode(fFightSeq.mfGetNextSequence(mfType()));
+						}
+						else
+						{
+							mfSetAttackMode(FIGHT_SEQUENCE::ATM_DEFEND);
+						}
 					}
+					mfSetAttackSequence(mfGetAttackMode());
+					mfSetMyTurnToAttack();
 				}
-				mfSetAttackSequence(mfGetAttackMode());
-				mfSetMyTurnToAttack();
 			}
 			else
 			{
@@ -2587,7 +2628,15 @@ void CAvatar::mfStartNextFightSequence()
 				if (hEnemy != fERROR)
 				{
 					CAvatar * const pEnemy = (CAvatar * const) BLKPTR(hEnemy);
-					pEnemy->mfSetMyTurnToAttack();
+					if (!IsPointerGood(pEnemy))
+					{
+						hEnemy = fERROR;
+						mfClearTurnToAttack();
+					}
+					else
+					{
+						pEnemy->mfSetMyTurnToAttack();
+					}
 				}
 			}
 			// Make an weapon swing/whoosh noise.
@@ -2616,16 +2665,27 @@ void CAvatar::mfSethEnemy(SHORT const EnemyHdl)
 	if (hEnemy != fERROR)
 	{
 		CAvatar * pEnemy = (CAvatar *) BLKPTR(hEnemy);
-		pEnemy->mfDisEngage();
-		if ( mfAmIBeingControled())
+		if (IsPointerGood(pEnemy))
 		{
-			pEnemy->mfTurnHighlightOff();
+			pEnemy->mfDisEngage();
+			if ( mfAmIBeingControled())
+			{
+				pEnemy->mfTurnHighlightOff();
+			}
 		}
 	}
 	
 	if (EnemyHdl != fERROR)
 	{
 		CAvatar * pEnemy = (CAvatar *) BLKPTR(EnemyHdl);
+		if (!IsPointerGood(pEnemy))
+		{
+			// Never adopt a stale enemy handle.
+			hEnemy = fERROR;
+			mfClearTurnToAttack();
+			mfDecideWhoseTurnToAttack();
+			return;
+		}
 		pEnemy->mfEngage();
 		if ( mfAmIBeingControled())
 		{
@@ -2660,6 +2720,10 @@ BOOL const CAvatar::mfIsMyTurnToAttack() const
 		else if (fAttackTurnFlag == 0)
 		{
 			CAvatar const * const pEnemy = (CAvatar const * const) BLKPTR(hEnemy);
+			if (!IsPointerGood(pEnemy))
+			{
+				return TRUE;
+			}
 			if (pEnemy->hEnemy != hThis ||
 			    pEnemy->Status != AI_ATTACK)
 			{

--- a/INVNGUI.CPP
+++ b/INVNGUI.CPP
@@ -1108,7 +1108,8 @@ void InventoryGUI::mfChangeCurrCat(LONG MenuCombo,LONG c)
 	SPLIT_LONG(MenuCombo, MenuId, ButtonId);
 	
 	for (LONG i = INV_BUT_MUNDANE; i <= INV_BUT_BLOODABLT; ++i)
-		HlMgr.SubdueButton(i);
+		if (HlMgr.Highlighted((SHORT)i))
+			HlMgr.SubdueButton(i);
 
 	LONG newArg=BUILD_LONG(MenuId, INV_BUT_MUNDANE+c);
 	

--- a/SCENE.CPP
+++ b/SCENE.CPP
@@ -1213,7 +1213,9 @@ void SCENE::mfDeleteAvatar(SHORT hAvatar)
 {
 	LONG i;
 	PTR_SCENE pScene = (PTR_SCENE) BLKPTR(SCENE_MGR::hCurrentScene);
-	
+	if (!IsPointerGood(pScene))
+		return;
+
 	for (i=0; i<MAX_AVATARS; i++)
 	{
 		if (pScene->Avatars[i] == hAvatar)
@@ -1240,6 +1242,11 @@ void SCENE::mfReleaseAvatars()
 		if( Avatars[i] != fERROR)
 		{
 			pAvatar = (CAvatar *) BLKPTR(Avatars[i]);
+			if (!IsPointerGood(pAvatar))
+			{
+				Avatars[i] = fERROR;
+				continue;
+			}
 			pAvatar->DoAI(CAvatar::AI_RELEASE);
 		}
 	}
@@ -1259,6 +1266,8 @@ LONG SCENE::mfAvatarIndex( LONG Id )
 		if (Avatars[i] != fERROR)
 		{
 			CAvatar *pAvatar = (CAvatar *) BLKPTR(Avatars[i]);
+			if (!IsPointerGood(pAvatar))
+				continue;
 			if (pAvatar->Id == Id)
 				return (i);
 		}
@@ -1286,12 +1295,16 @@ void SCENE::mfSceneButtonObject(
 		
 		SetBlockAttr(SCENE_MGR::hCurrentScene, LOCKED, LOCKED);
 		PTR_SCENE pScene = (PTR_SCENE) BLKPTR(SCENE_MGR::hCurrentScene);
-		
+		if (!IsPointerGood(pScene))
+			return;
+
 		for (i = 0; i < MAX_AVATARS; i++)
 		{
 			if (pScene->Avatars[i] != fERROR)
 			{
 				CAvatar *pAvatar = (CAvatar *) BLKPTR(pScene->Avatars[i]);
+				if (!IsPointerGood(pAvatar))
+					continue;
 				if (pAvatar->ThingIndex == objClicked)
 				{
 					bObjFound = TRUE;
@@ -1570,12 +1583,16 @@ void SCENE::mfDrawMapStuff ( void )
 	if (SCENE_MGR::hCurrentScene != fERROR)
 	{
 		PTR_SCENE pCurrentScene = (PTR_SCENE) BLKPTR(SCENE_MGR::hCurrentScene);
-	
+		if (!IsPointerGood(pCurrentScene))
+			return;
+
  		for(i = 0; i < MAX_AVATARS; i++ )
  		{
  			if(pCurrentScene->Avatars[i] != fERROR )
  			{
  				CAvatar *pAvatar = (CAvatar *) BLKPTR(pCurrentScene->Avatars[i]);
+				if (!IsPointerGood(pAvatar))
+					continue;
 				if (pAvatar->Status!=CAvatar::AI_DEAD)
 					HandleMapAvatar(pAvatar->ThingIndex,pCurrentScene->Avatars[i],MAP_RED,MAP_SCALED);
  			}

--- a/SCNAI.CPP
+++ b/SCNAI.CPP
@@ -574,14 +574,18 @@ void SCENE_AI::mfAdventureInit ( SCENE &rScene)
 			// Initialize the Regent to be the current picker up of things
 			// clicked on.
 			CAvatar *pAvatar = (CAvatar *) BLKPTR(units[UnitIndex].iHandle);
-			pAvatar->mfSetMeToThePlayer();
-			
+			if (IsPointerGood(pAvatar))
+				pAvatar->mfSetMeToThePlayer();
+
 			do
 			{
 				pAvatar = (CAvatar *) BLKPTR(units[UnitIndex].iHandle);
-				pAvatar->SetAIFuncIndex(CAvatar::AI_FUNC_FOLLOW_PLAYER);
-				pAvatar->mfInitVals();
-				pAvatar->fFollowPlayer.mfJoinAdventureTeam();
+				if (IsPointerGood(pAvatar))
+				{
+					pAvatar->SetAIFuncIndex(CAvatar::AI_FUNC_FOLLOW_PLAYER);
+					pAvatar->mfInitVals();
+					pAvatar->fFollowPlayer.mfJoinAdventureTeam();
+				}
 				UnitIndex = (SHORT) units[UnitIndex].NextUnit;
 			} while(UnitIndex != -1);
 		}
@@ -594,8 +598,9 @@ void SCENE_AI::mfAdventureInit ( SCENE &rScene)
 			if (rScene.Avatars[i] != fERROR)
 			{
 				CAvatar * const pAvatar = (CAvatar * const) BLKPTR(rScene.Avatars[i]);
-				pAvatar->DoAI(CAvatar::AI_INIT);
-				
+				if (IsPointerGood(pAvatar))
+					pAvatar->DoAI(CAvatar::AI_INIT);
+
 				// Hey he could have died!
 				//GEH if (rScene.Avatars[i] != fERROR)
 			}
@@ -677,8 +682,9 @@ void SCENE_AI::mfAdventurePlay (SCENE &rScene)
 				{
 					CAvatar * const pAvatar = (CAvatar * const ) BLKPTR(rScene.Avatars[i]);
 					
-					pAvatar->DoAI();
-					
+					if (IsPointerGood(pAvatar))
+						pAvatar->DoAI();
+
 					// Hey he could have died!
 					//GEH if (rScene.Avatars[i] != fERROR)
 				}

--- a/SPELLEFF.CPP
+++ b/SPELLEFF.CPP
@@ -992,6 +992,8 @@ LONG ItemEffects::DeathSpell(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 	
 					DICE			dice={0,0,0};
@@ -1070,6 +1072,8 @@ LONG ItemEffects::Blindness(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 	
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 	
 					OldhEnemies.mfAddEffect(hAvatarStats,pAvatar->hEnemy);
@@ -1097,6 +1101,8 @@ LONG ItemEffects::Blindness(LONG Combo,LONG Arg,LONG Action)
 #endif
 
 				DumbHandlePtr<CAvatar>		pEnemy(*phEnemy);
+				if (pEnemy->hPlayerStats == fERROR)
+					return CANT_COMPLETE;
 				DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 				
 				Item.mfMessage(STR_DEACTIVATE_BLINDNESS);
@@ -1184,6 +1190,8 @@ LONG ItemEffects::PowerBlindSpell(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 	
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 			
 					OldhEnemies.mfAddEffect(hAvatarStats,pAvatar->hEnemy);
@@ -1211,6 +1219,8 @@ LONG ItemEffects::PowerBlindSpell(LONG Combo,LONG Arg,LONG Action)
 #endif
 
 				DumbHandlePtr<CAvatar>		pEnemy(*phEnemy);
+				if (pEnemy->hPlayerStats == fERROR)
+					return CANT_COMPLETE;
 				DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 				
 				Item.mfMessage(STR_DEACTIVATE_BLINDNESS);
@@ -1380,6 +1390,8 @@ LONG ItemEffects::PowerKillSpell(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS const> const pEnemyStats(pEnemy->hPlayerStats);
 	
 					mfSound(SND_POWER_KILL1,NULL,pAvatar->ThingIndex);
@@ -1815,6 +1827,8 @@ LONG ItemEffects::TurnUndead(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS > const pEnemyStats(pEnemy->hPlayerStats);
 			
 					DICE			DamageDice;
@@ -1894,6 +1908,8 @@ LONG ItemEffects::StoneUndead(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 	
 					if(ThingIsEvil(pEnemy->ThingType) &&
@@ -1957,6 +1973,8 @@ LONG ItemEffects::FleshToStone(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 	
 					if (!SaveVs(pEnemy->hPlayerStats,ST_SPELL,0))
 					{
@@ -2086,8 +2104,7 @@ LONG ItemEffects::SpritualHammer(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
-					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
-	
+
 					LONG PriestLevel=0;
 					
 					LONG PriestClass=pPlayerStats->mfGetSpellCastClass(SPELL_INFO::PRIEST);
@@ -2165,10 +2182,13 @@ LONG ItemEffects::ProtectionFromEvil(LONG Combo,LONG Arg,LONG Action)
 				     AdvItor != ADVENTURER::end();
 				     AdvItor++)
 				{
-					CAvatar const * const pAvatar = (CAvatar const * const) BLKPTR(*AdvItor);
-					SHORT hStats=pAvatar->hPlayerStats;
-					PLAYER_STATS* const pAvatarStats=(PLAYER_STATS* const)BLKPTR(hStats);
-					
+					if (*AdvItor == fERROR)
+						continue;
+					DumbHandlePtr<CAvatar> const pAvatar(*AdvItor);
+					if (pAvatar->hPlayerStats == fERROR)
+						continue;
+					DumbAutoLockPtr<PLAYER_STATS> const pAvatarStats(pAvatar->hPlayerStats);
+
 					pAvatarStats->StatsMod.mfModifyStats(STATSMOD::EVIL_RESIST_MOD,2);
 
 				}
@@ -2185,10 +2205,13 @@ LONG ItemEffects::ProtectionFromEvil(LONG Combo,LONG Arg,LONG Action)
 				     AdvItor != ADVENTURER::end();
 				     AdvItor++)
 				{
-					CAvatar const * const pAvatar = (CAvatar const * const) BLKPTR(*AdvItor);
-					SHORT hStats=pAvatar->hPlayerStats;
-					PLAYER_STATS* const pAvatarStats=(PLAYER_STATS* const)BLKPTR(hStats);
-					
+					if (*AdvItor == fERROR)
+						continue;
+					DumbHandlePtr<CAvatar> const pAvatar(*AdvItor);
+					if (pAvatar->hPlayerStats == fERROR)
+						continue;
+					DumbAutoLockPtr<PLAYER_STATS> const pAvatarStats(pAvatar->hPlayerStats);
+
 					pAvatarStats->StatsMod.mfModifyStats(STATSMOD::EVIL_RESIST_MOD,-2);
 
 				}
@@ -2255,6 +2278,8 @@ LONG ItemEffects::Disintigrate(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 	
 					if (!SaveVs(pEnemy->hPlayerStats,ST_SPELL,0))
@@ -2394,6 +2419,8 @@ LONG ItemEffects::FlameStrike(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 					
 					DICE			const DamageDice = {6,8,0};
@@ -2608,6 +2635,8 @@ LONG ItemEffects::ShockingGrasp(LONG Combo,LONG Arg,LONG Action)
 						return CANT_COMPLETE;
 					
 					DumbHandlePtr<CAvatar>		pEnemy(pAvatar->hEnemy);
+					if (pEnemy->hPlayerStats == fERROR)
+						return CANT_COMPLETE;
 					DumbAutoLockPtr<PLAYER_STATS> const pEnemyStats(pEnemy->hPlayerStats);
 					DICE						DamageDice = {1,8,0};
 	
@@ -2835,13 +2864,15 @@ LONG ItemEffects::UndeadTurn(LONG Combo,LONG Arg,LONG Action)
 		{
 			case ACTIVATE:
 				{
-				PLAYER_STATS * const pPlayerStats=(PLAYER_STATS* const)BLKPTR(hPlayerStats);
+				if (hPlayerStats == fERROR)
+					return NOT_SUPPORTED;
+				DumbAutoLockPtr<PLAYER_STATS> const pPlayerStats(hPlayerStats);
 				SHORT 		const hAvatar = pPlayerStats->hAvatar;
 				
 				if (hAvatar == fERROR)
 					return NOT_SUPPORTED;
 					
-				CAvatar			*pAvatar=(CAvatar*)BLKPTR((SHORT)hAvatar);
+				DumbHandlePtr<CAvatar>		pAvatar(hAvatar);
 				
 				SBYTE	level = 1;
 				DICE	dice;
@@ -2865,7 +2896,7 @@ LONG ItemEffects::UndeadTurn(LONG Combo,LONG Arg,LONG Action)
 				if(pAvatar->hEnemy == fERROR)
 					return NOT_SUPPORTED;
 				
-				CAvatar const * const pEnemy=(CAvatar const * const)BLKPTR((SHORT)pAvatar->hEnemy);
+				DumbHandlePtr<CAvatar> const pEnemy(pAvatar->hEnemy);
 				if( ThingIsEvil (pEnemy->ThingType))
 				{
 					pAvatar->mfSetDamageDealt( damage);
@@ -3099,6 +3130,9 @@ void ResurrectionMenu::Paint(LONG MenuCombo, LONG Arg)
 	LONG ButtonID;
 	SPLIT_LONG(MenuCombo,MenuIdx,ButtonID);
 
+	for (i = 0; i < 4; ++i)
+		StatsHdls[i] = fERROR;
+
 	ADVENTURER_TEAM_ITOR AdvItor;
 
 	AdvItor=ADVENTURER::begin();
@@ -3138,7 +3172,7 @@ void ResurrectionMenu::Paint(LONG MenuCombo, LONG Arg)
 void ResurrectionMenu::Resurrect(LONG MenuCombo, LONG Arg)
 {	
 		
-	if (StatsHdls[Arg]==fERROR)
+	if (Arg < 0 || Arg >= 4 || StatsHdls[Arg]==fERROR)
 		return;
 
 	HideSubMenu(0,D_RESURRECT_MENU);

--- a/THINGS.C
+++ b/THINGS.C
@@ -3093,8 +3093,20 @@ SHORT NextAnimFrame (SHORT iAnim, USHORT sequence, USHORT rotation, UBYTE * pCtr
 
 			for(i=pAnim->frame; i<tmpFrame; ++i)
 			{
+				if ( pAnim->offData >= (ULONG)pHead->size)
+				{
+#if defined(_DEBUG)
+					printf("WARNING! Things.c is missing %d frames.\n",
+					        (LONG)(pAnim->totalFrames - pAnim->frame));
+#endif
+					pHead->frames = pAnim->frame;
+					pAnim->totalFrames = pAnim->frame;
+					break;
+				}
+				
 				++pAnim->frame;
-				decode_frame(pAnim, pHead);
+				if (decode_frame(pAnim, pHead) == fERROR)
+					break;
 			}
 
 		}
@@ -3148,7 +3160,8 @@ SHORT NextAnimFrame (SHORT iAnim, USHORT sequence, USHORT rotation, UBYTE * pCtr
 		}
 		
 		++pAnim->frame;
-		decode_frame(pAnim, pHead);	/* advance to next frame */
+		if (decode_frame(pAnim, pHead) == fERROR)	/* advance to next frame */
+			break;
 	}
 
 	/* set control frame number */
@@ -3187,6 +3200,14 @@ ERRCODE decode_frame (ANIMPTR pAnim, 	FLICHEADPTR pHead)
 	FRAMEHEADPTR	pFramehd;
 	CHUNKHEADPTR	pChunk;
 	PTR				pData;
+
+	/* Paged out or non-existent art; a stale block here would fault on the
+	   pFramehd->size read below, crashing to desktop with no Fatal.err. */
+	if (!IsPointerGood(pAnim) || !IsPointerGood(pHead))
+		return fERROR;
+	
+	if (pAnim->offData >= (ULONG)pHead->size)
+		return fERROR;
 
 #if defined(_DEBUG)
 	//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
…g to desktop

Ported from birp-dev b719e5b, 9f07a14, d8cb003.

Adapted birp-dev's "BLKPTR returned NULL" guards to birthrt's idiom: its BLKPTR returns pHeap+offset and never yields NULL, so every guard uses IsPointerGood() instead - the same test MEMMANAG's IsHandleFlushed() is built from. THINGS.C now degrades animations (stops at the last decodable frame) rather than faulting on paged-out art; the size compare is cast to ULONG to avoid new signed/unsigned warnings.

Left out: all logInfo/logWarn/logError calls and the "logger.h" includes (birthrt has no logger), the ReportFreeMem diagnostics and the SCNAI log-spam rate limiter that only existed to throttle them. The myThingBumped range guards AIFOLPLY is still missing come from a different birp-dev commit and were left for that port.