### PR TITLE
port(issues 10,32): start menu music at launch and adventure music on…

### DIFF
--- a/AMBIENCE.INC
+++ b/AMBIENCE.INC
@@ -233,4 +233,4 @@ LONG AmbientSoundScene5[] =
 };
 
 // make this zero_based
-#define AMBIENT_SOUND_SCENE_5_TOTAL (sizeof(AmbientSoundScene4)/sizeof(LONG))
+#define AMBIENT_SOUND_SCENE_5_TOTAL (sizeof(AmbientSoundScene5)/sizeof(LONG))

--- a/CHARSEL.CPP
+++ b/CHARSEL.CPP
@@ -670,6 +670,9 @@ void NewGameConfirmed(LONG,LONG lMultiFlag)
 	fclose(fp);
 	date = 0;
 
+	ucWhichTrack = REDBOOK_REALM;
+	PlayTrack(REDBOOK_REALM);
+
 	NewGameConfirmed2( FALSE );
 
 }

--- a/LOADSAVE.CPP
+++ b/LOADSAVE.CPP
@@ -1736,6 +1736,9 @@ void LoadGameDo(LONG MenuCombo, LONG )
 	SetRedrawMainMapLevel();
 	fFadedOut = -1;
 	
+	ucWhichTrack = REDBOOK_REALM;
+	PlayTrack(REDBOOK_REALM);
+
 	if (ScenarioInfo.IsScenario)		// [abc] 10/6/97
 		NewGameConfirmed2(FALSE);
 	

--- a/MAIN.CPP
+++ b/MAIN.CPP
@@ -793,6 +793,14 @@ void GameMain(void)
 	clear_key_status(0);
 	ResumeSuspendedMusic();
 
+	// nothing had kicked off the menu/realm track, so the main menu came up
+	// silent and stayed that way until something else called PlayTrack
+	if (fMusic)
+	{
+		ucWhichTrack = REDBOOK_REALM;
+		PlayTrack(ucWhichTrack);
+	}
+
 	// begin with the domain turn
 	if (JustLoadWad)
 	{
@@ -1667,6 +1675,28 @@ void CheckTheCDMusic(void)
 {
 	static LONG StartTime = 0;
 	static SHORT delayTicks;
+	static LONG SuspendedStartTime = 0;
+
+	// While music is suspended PlayTrack is a no-op, so don't restart the
+	// track here.  If something suspended it and never resumed, bail us out
+	// after 12 seconds so an adventure/combat doesn't run silent.
+	if(IsMusicSuspended())
+	{
+		if(fMusic && (ucWhichTrack != 100) &&
+			( (master_game_type == GAME_ADVENTURE) || gfInCombat) )
+		{
+			if(SuspendedStartTime == 0)
+				SuspendedStartTime = get_time();
+			else if( ( (get_time() ) - SuspendedStartTime) > (18 * 12) )	// 18 ticks/second
+			{
+				ResumeSuspendedMusic();
+				SuspendedStartTime = 0;
+			}
+		}
+		return;
+	}
+
+	SuspendedStartTime = 0;
 
 	if(fMusic && !CheckCDBusy() && 	(ucWhichTrack != 100) )
 	{

--- a/PRACTICE.CPP
+++ b/PRACTICE.CPP
@@ -3768,6 +3768,8 @@ void SelectGameType(LONG MenuCombo, LONG type)
 
 				dturn_mode = REPORT_DONE_MODE;
 				SetRedrawMainMapLevel();
+				ResumeSuspendedMusic();
+				PlayTrack(REDBOOK_REALM);
 
 				fControlMode = (type-10) | 0x100;	// selected tutorial
 				break;
@@ -3863,6 +3865,8 @@ void SelectGameType(LONG MenuCombo, LONG type)
 			AddGameKeys();
 			
 			fTutorialSelected = FALSE;
+			ResumeSuspendedMusic();
+			PlayTrack(REDBOOK_REALM);
 			RunAdvOnly();
 			
 			DescribeAdventure();
@@ -3908,6 +3912,8 @@ void SelectGameType(LONG MenuCombo, LONG type)
 			AddGameKeys();
 			
 			fTutorialSelected = FALSE;
+			ResumeSuspendedMusic();
+			PlayTrack(REDBOOK_REALM);
 			RunBattlesOnly();
 			
 			RunMenus();

--- a/REDBOOK.C
+++ b/REDBOOK.C
@@ -625,6 +625,11 @@ void ResumeSuspendedMusic(void)
 	MusicSuspended = FALSE;
 }
 
+BOOL IsMusicSuspended(void)
+{
+	return MusicSuspended;
+}
+
 int GetMusicVolume(void)
 {
 	return(VolumeIndex);

--- a/SCNAI.CPP
+++ b/SCNAI.CPP
@@ -539,9 +539,10 @@ void SCENE_AI::mfAdventureInit ( SCENE &rScene)
 	if (TRUE == AdventureAllocateData(rScene))
 	{
 		LONG 	i;
-	
-		PlayTrack(ucWhichTrack);
-		
+
+		// music is still suspended while the scene loads, so PlayTrack here
+		// did nothing.  mfLoadScene replays the track after it resumes.
+
 		set_margin_size(0, 0, 0, 0);
 		
 		SetSoundDecay(300, 1000);

--- a/SCNMGR.CPP
+++ b/SCNMGR.CPP
@@ -464,6 +464,17 @@ LONG const SCENE_MGR::mfLoadScene(
 		add_task(1,TextureFrameHandler,0);  //once every frame check lighting effects
 	}
 	ResumeSuspendedMusic();
+
+	// Adventure init requests track playback while music is suspended during
+	// scene load; replay after resume so first-entry adventure music starts.
+	{
+		SCENE_AI::STATE			SceneState;
+		SCENE_AI::SCENE_TYPE	SceneType;
+
+		pCurrentScene->mfGetSceneAIState(&SceneState, &SceneType);
+		if (SceneType == SCENE_AI::ADVENTURE_SCENE)
+			PlayTrack(ucWhichTrack);
+	}
 	return fNOERR;
 	
 Error:

--- a/SOUND.CPP
+++ b/SOUND.CPP
@@ -92,7 +92,7 @@ extern HINSTANCE hInstApp;
 /* ------------------------------------------------------------------------
    Global Variables
    ------------------------------------------------------------------------ */
-BOOL PlayEnvironmentalSounds = TRUE;
+BOOL PlayEnvironmentalSounds = FALSE;	// no scene loaded yet, so no ambience
 BOOL UIPlayEnvironmentalSounds = TRUE;
 SHORT WhichEnvironmentalSound = 0;
 #ifdef _WINDOWS
@@ -224,6 +224,10 @@ SHORT AddSndObj( BIRTHRT_SND  WaveID, SHORT randomCount, LONG MyThingsIndex)
 	// calculate distance from camera to thing
 	else
 	{
+		// a released or never-created thing leaves a stale index behind
+		if(MyThingsIndex >= MAX_THINGS || mythings[MyThingsIndex].valid != TRUE)
+			return fERROR;
+
 		// set the pan
 		pan = CalculatePan(MyThingsIndex);
 		volume = aprox_dist(PLAYER_INT_VAL(player.x),
@@ -427,10 +431,31 @@ void UpdateLoopingSoundObjects(void)
 
 			else
 			{
+				const LONG ThingIndex = LoopingSoundThing[i].ThingTypeIndex;
+
+				// the thing this loop was attached to can go away with the
+				// scene; drop the entry instead of reading past mythings
+				if(ThingIndex < 0 || ThingIndex >= MAX_THINGS || mythings[ThingIndex].valid != TRUE)
+				{
+					if(LoopingSoundThing[i].InstanceTag != fERROR)
+					{
+#ifdef WINDOWS_SOUND
+						PauseWave(LoopingSoundThing[i].wave);
+#else
+#ifdef AUDIO_LIB
+						kernel->AudioStop(LoopingSoundThing[i].wave, LoopingSoundThing[i].InstanceTag);
+#endif
+#endif
+						LoopingSoundCount--;
+					}
+					RemoveLoopingSoundFromArray(i);
+					continue;
+				}
+
 				distance= aprox_dist(PLAYER_INT_VAL(player.x),
 			               			  PLAYER_INT_VAL(player.y),
-			               			  mythings[LoopingSoundThing[i].ThingTypeIndex].x,
-			               			  mythings[LoopingSoundThing[i].ThingTypeIndex].y);
+			               			  mythings[ThingIndex].x,
+			               			  mythings[ThingIndex].y);
 
 				distance = TweakVolume(distance);
 			}
@@ -503,6 +528,9 @@ Arguments  the index into the array returned by AddLoopingSound (above)
 extern "C"
 void RemoveLoopingSound(LONG ArrayIndex)
 {
+	// AddLoopingSound hands back fERROR when the array is full
+	if(ArrayIndex < 0 || ArrayIndex >= MAX_SOUND_THINGS)
+		return;
 
 	if(LoopingSoundThing[ArrayIndex].InstanceTag != fERROR)
 	{
@@ -625,7 +653,9 @@ void ServiceSOLAudio(void)
 		KernelAudioService();
 #endif
 
-	if(PlayEnvironmentalSounds && UIPlayEnvironmentalSounds && SFXVolumeIndex)
+	// WhichEnvironmentalSound is the scene's ambience profile; 0 means the
+	// current scene has none, so don't run the countdown at all
+	if(PlayEnvironmentalSounds && UIPlayEnvironmentalSounds && SFXVolumeIndex && (WhichEnvironmentalSound > 0) )
 	{
 		// play random environmental sounds at random number of frames
 		FramesTilNextSound--;

--- a/SOUND.HXX
+++ b/SOUND.HXX
@@ -143,6 +143,7 @@ enum {
    ----------------------------------------------------------------- */
 void SuspendMusic(void);
 void ResumeSuspendedMusic(void);
+BOOL IsMusicSuspended(void);
 int GetMusicVolume(void);
 
 void SetMusicVolume(int,int,int);


### PR DESCRIPTION
… entry

Ported from birp-dev bd7da33.

Adapted to birthrt's tree: IsMusicSuspended() is declared in SOUND.HXX (where birthrt already keeps SuspendMusic/ResumeSuspendedMusic) rather than REDBOOK.H, and GameMain's new PlayTrack needs no _DEMO guard since birthrt dropped that block. Left out all logger.h calls (birthrt has no logger), the PlayTrack "case 121" (birthrt's rewritten default case already resolves any track to MUSIC\<id>.WAV), and the SOLAUDIO AUDIOWIN/KERNAUD audioMgr move (birthrt's KERNAUD.CPP is a rewrite that never defines or uses audioMgr).