### PR TITLE
port(issue-14): faster exit from adventure combat, clearer combat sta…

### DIFF
--- a/COMBATUI.CPP
+++ b/COMBATUI.CPP
@@ -2565,10 +2565,15 @@ void CombatLowAttackKey(LONG menuid, LONG SwingFast)
    ======================================================================== */
 void CombatTurnDoneKey(LONG /* unused */, LONG /* unused */ )
 {
-	// Only enabled if RPG mode is on.
+	// Only enabled if RPG mode is on.  In arcade mode the same bottom bar button
+	// is the Halt command; GAMEMENU.H hardwires this proc onto the button, so
+	// dispatch rather than repointing the button (and its live region) at runtime.
 	if (COMBAT_MODE::mfIsModeRPG() == FALSE)
+	{
+		CombatHaltKey(0, 0);
 		return;
-		
+	}
+
 	if (mouse_button == 2)
 	{
 		// Display help dialog on right click
@@ -2639,6 +2644,76 @@ void CombatTurnDoneKey(LONG /* unused */, LONG /* unused */ )
 		{
 			DumbAutoLockPtr<COMBAT_SCENE_DATA> const pcsdData(pCurrentScene->fhData);
 			pcsdData->mfInitRPGTimer();
+		}
+	}
+}
+
+/* ========================================================================
+   Function    - CombatHaltKey
+   Description - Set all PCs to Defend, stopping pursuit and holding
+   				 position. Allows auto-end of combat to trigger.
+   				 (Arcade mode only)
+   Returns     -
+   ======================================================================== */
+void CombatHaltKey(LONG /* unused */, LONG /* unused */)
+{
+	// Only enabled if RPG mode is off.
+	if (COMBAT_MODE::mfIsModeRPG() == TRUE)
+		return;
+
+	if (mouse_button == 2)
+	{
+		// Display help dialog on right click.
+		// birthrt ships a prebuilt STRDAT.DAT, so there is no string id to add
+		// these two to; they go through the literal-text SystemHelp overload.
+		static CHAR HaltHelpTitle[] = "Halt";
+		static CHAR HaltHelpText[] = "Sets all party members to Defend, stopping pursuit and "
+		                             "holding position. Combat will end automatically a few "
+		                             "seconds after the last attack.";
+
+		mouse_click = 0;
+		SystemHelp(HaltHelpTitle, HaltHelpText, H_Adventure_Done_Button, 0, 0);
+	}
+	else if ((mouse_click == 1 && mouse_button == 1) || mouse_click == 0)
+	{
+		mouse_click = 0;
+		// click the button
+		SetButtonHilight(D_COMBAT_RPGBOTTOM_BAR, BUTNO_RPG_DONE, TRUE);
+		fUpdatePanels = TRUE;
+		RunPanels();
+		RunMenus();
+		update_screen();
+		TickDelay(4);
+		SetButtonHilight(D_COMBAT_RPGBOTTOM_BAR, BUTNO_RPG_DONE, FALSE);
+		fUpdatePanels = TRUE;
+		RunPanels();
+		RunMenus();
+		update_screen();
+		TickDelay(4);
+
+		if (SCENE_MGR::hCurrentScene == fERROR)
+		{
+			return;
+		}
+
+		SCENE * const pCurrentScene = (SCENE * const) BLKPTR(SCENE_MGR::hCurrentScene);
+
+		SCENE_AI::STATE SceneState;
+		SCENE_AI::SCENE_TYPE SceneType;
+		pCurrentScene->mfGetSceneAIState(&SceneState,
+						                 &SceneType);
+
+		if (SceneType != SCENE_AI::COMBAT_SCENE)
+		{
+			return;
+		}
+
+		CONTROL_PANELS::mfHaltAllToDefend();
+
+		if (pCurrentScene->fhData != fERROR)
+		{
+			DumbAutoLockPtr<COMBAT_SCENE_DATA> const pcsdData(pCurrentScene->fhData);
+			pcsdData->mfInitCombatTimer();
 		}
 	}
 }

--- a/COMBATUI.HXX
+++ b/COMBATUI.HXX
@@ -96,6 +96,7 @@ void CombatCastSpellBox(LONG /* hAvatar */, LONG /* SpellBoxNumber */ );
 void CombatMenuPaint(LONG /* menuid */, LONG /* hAvatar */ );
 
 void CombatTurnDoneKey(LONG /* unused */, LONG /* unused */ );
+void CombatHaltKey(LONG /* unused */, LONG /* unused */);
 void CombatRetreatKey(LONG /* menuid */, LONG /* unused */);
 void CombatNewLeaderKey(LONG /* unused */, LONG /* unused */);
 void CombatReturnToMap(LONG /* unused */ , LONG /* unused */ );

--- a/COMBCNTL.CPP
+++ b/COMBCNTL.CPP
@@ -457,34 +457,23 @@ void CONTROL_PANELS::CURRENT_CONTROL::mfPaintPanel()
 		case CAvatar::AI_ATTACK:
 			if (pAvatar->hEnemy != fERROR)
 			{
-				LONG ToHit = pAvatar->mfToHitEnemy(pAvatar->hEnemy);
-				if (mundane_descriptions)
+				// The reworked combat status lines below are literal text: birthrt
+				// ships a prebuilt STRDAT.DAT, so no string ids can be added for
+				// the new wording without indexing past the end of the table.
+				CAvatar const * const pEnemy = (CAvatar const * const) BLKPTR(pAvatar->hEnemy);
+
+				if (pEnemy->hPlayerStats != fERROR)
 				{
-					if (ToHit > 20)
-					{
-						ToHit = 20;
-					}
-					else if (ToHit < 2)
-					{
-						ToHit = 2;
-					}
-					ToHit = (21 - ToHit) * 5;
-					strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_HIT_CHANCE), sizeof(cpFormatBuffer));
+					DumbHandlePtr <PLAYER_STATS const> const dhEnemyStats(pEnemy->hPlayerStats);
+					strncpy(cpNameBuffer, dhEnemyStats->mfGetName(), sizeof(cpNameBuffer));
+					sprintf(cpBuffer, "Attacking %s (AC%hd)",
+					                  cpNameBuffer,
+					                  (SHORT)dhEnemyStats->mfGetArmorClass());
 				}
 				else
 				{
-					strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_RPG_HIT_CHANCE), sizeof(cpFormatBuffer));
-				}
-				
-				if (pAvatar->mfGetAttackMode() == FIGHT_SEQUENCE::ATM_QUICK_HIGH ||
-					pAvatar->mfGetAttackMode() == FIGHT_SEQUENCE::ATM_QUICK_LOW)
-					
-				{
-					sprintf(cpBuffer, cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_QUICK),ToHit);
-				}
-				else
-				{
-					sprintf(cpBuffer, cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_SLOW),ToHit);
+					sprintf(cpBuffer, "Attacking %s",
+					                  GAME_TTYPE::mfGetDescription(pEnemy->mfType()));
 				}
 			}
 			else
@@ -526,98 +515,74 @@ void CONTROL_PANELS::CURRENT_CONTROL::mfPaintPanel()
 				if (pEnemy->hPlayerStats != fERROR)
 				{
 					DumbHandlePtr <PLAYER_STATS const> const dhEnemyStats(pEnemy->hPlayerStats);
-					strcpy( cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_DEFENDING));
-					sprintf(cpBuffer, cpFormatBuffer, 
-										dhEnemyStats->mfGetName(),
-										(SHORT)dhEnemyStats->mfGetArmorClass() );
+					strncpy(cpNameBuffer, dhEnemyStats->mfGetName(), sizeof(cpNameBuffer));
+					sprintf(cpBuffer, "Defending against %s", cpNameBuffer);
 				}
+				else
+				{
+					sprintf(cpBuffer, "Defending against %s",
+					                  GAME_TTYPE::mfGetDescription(pEnemy->mfType()));
+				}
+			}
+			else
+			{
+				strncpy(cpBuffer, "Defending", sizeof(cpBuffer));
 			}
 			break;
 		case CAvatar::AI_ATTACK:
 			if (pAvatar->hEnemy != fERROR)
 			{
-				CAvatar const * const pEnemy = (CAvatar const * const) BLKPTR(pAvatar->hEnemy);
-				if (pEnemy->hPlayerStats != fERROR)
+				LONG const dmg = pAvatar->mfGetDamageDealt();
+				LONG ToHit = pAvatar->mfToHitEnemy(pAvatar->hEnemy);
+				if (ToHit > 20)
 				{
-					DumbHandlePtr <PLAYER_STATS> const dhEnemyStats(pEnemy->hPlayerStats);
-					// Damage calculations haven't occured yet
-					LONG minDamage;
-					LONG maxDamage;
-					
-					PLAYER_HIT const PlayerHitObj(dhPlayerStats, dhEnemyStats);
-					PlayerHitObj.mfDamageRange(pEnemy->mfType(), &minDamage, &maxDamage);
-					if (pAvatar->mfGetAttackMode() == FIGHT_SEQUENCE::ATM_QUICK_HIGH ||
-						pAvatar->mfGetAttackMode() == FIGHT_SEQUENCE::ATM_QUICK_LOW)
-					
-					{
-						maxDamage *= 2;
-					}
-					
-					if (pAvatar->mfGetDamageDealt()< 0)
-					{
-						strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_ATTACKING),sizeof(cpFormatBuffer));
-						sprintf(cpBuffer, cpFormatBuffer,
-							        minDamage,
-							        maxDamage);
-					}
-					else
-					{
-						if (pAvatar->mfGetDamageDealt() == 0)
-						{
-							// We missed.
-								strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_SWING_MISS), sizeof(cpFormatBuffer));
-								sprintf(cpBuffer, cpFormatBuffer,
-											  minDamage,
-											  maxDamage );
-						}
-						else
-						{
-							// We hit'em!
-							strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_HIT_FOR), sizeof(cpFormatBuffer));
-							sprintf(cpBuffer, cpFormatBuffer, 
-			                                  minDamage,
-			                                  maxDamage,
-			                                  pAvatar->mfGetDamageDealt());
-						}
-					}
+					ToHit = 20;
+				}
+				else if (ToHit < 2)
+				{
+					ToHit = 2;
+				}
+				ToHit = (21 - ToHit) * 5;
+
+				// LONG is `long` on Win32 but int32_t elsewhere, so pin the
+				// varargs to int rather than relying on %ld.
+				if (dmg < 0)
+				{
+					sprintf(cpBuffer, "%d%% chance to hit", (int)ToHit);
+				}
+				else if (dmg == 0)
+				{
+					// We missed.
+					sprintf(cpBuffer, "%d%% chance to hit... missed!", (int)ToHit);
 				}
 				else
 				{
-					sprintf(cpBuffer, STRMGR_GetStr(COMBAT_STR_CANT_ENGAGE));
+					// We hit'em!
+					sprintf(cpBuffer, "%d%% chance to hit... hits for %d damage!", (int)ToHit, (int)dmg);
 				}
 			}
 			else
 			{
-				sprintf(cpBuffer, STRMGR_GetStr(COMBAT_STR_CANT_ENGAGE));
+				sprintf(cpBuffer, STRMGR_GetStr(COMBAT_STR_AWAITING_CMD));
 			}
 			break;
 		case CAvatar::AI_FALLBACK:
+			strncpy(cpBuffer, "Retreating", sizeof(cpBuffer));
+			break;
+		case CAvatar::AI_MOVING:
 			if (pAvatar->hEnemy != fERROR)
 			{
 				CAvatar const * const pEnemy = (CAvatar const * const) BLKPTR(pAvatar->hEnemy);
 				if (pEnemy->hPlayerStats != fERROR)
 				{
 					DumbHandlePtr <PLAYER_STATS const> const dhEnemyStats(pEnemy->hPlayerStats);
-					
-					strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_FALLING_BACK), sizeof(cpFormatBuffer));
-					sprintf(cpBuffer, cpFormatBuffer, 
-									    dhEnemyStats->mfGetName(),
-										(SHORT)dhEnemyStats->mfGetArmorClass() );
+					strncpy(cpNameBuffer, dhEnemyStats->mfGetName(), sizeof(cpNameBuffer));
+					sprintf(cpBuffer, "Engaging %s", cpNameBuffer);
 				}
-			}
-			break;
-		case CAvatar::AI_MOVING:
-			if (pAvatar->hEnemy != fERROR)
-			{
-				CAvatar *pEnemy = (CAvatar *) BLKPTR(pAvatar->hEnemy);
-				if (pEnemy->hPlayerStats != fERROR)
+				else
 				{
-					DumbHandlePtr <PLAYER_STATS const> const dhEnemyStats(pEnemy->hPlayerStats);
-					
-					strncpy(cpFormatBuffer, STRMGR_GetStr(COMBAT_STR_CHASING), sizeof (cpFormatBuffer));
-					sprintf(cpBuffer, cpFormatBuffer,
-										dhEnemyStats->mfGetName(),
-										(SHORT)dhEnemyStats->mfGetArmorClass() );
+					sprintf(cpBuffer, "Engaging %s",
+					                  GAME_TTYPE::mfGetDescription(pEnemy->mfType()));
 				}
 			}
 			break;

--- a/COMBCNTL.HXX
+++ b/COMBCNTL.HXX
@@ -148,6 +148,7 @@ public:
 	inline	static void mfCurrentSpeakAcknowledgement();
 	inline	static void mfSetCurrentToLeader();
 	inline	static void mfSetAllDefend();
+	inline	static void mfHaltAllToDefend();
 			static void mfInitAllPanels();
 			static void mfCycleToNextPanel();
 			static void mfUpdateOptions();
@@ -375,6 +376,43 @@ inline void CONTROL_PANELS::mfSetAllDefend()
 			if (!pAvatar->mfAmIImmoblized())
 			{
 				pAvatar->mfSetAttackMode(FIGHT_SEQUENCE::ATM_DEFEND);
+				pAvatar->mfSetAttackSequence(FIGHT_SEQUENCE::ATM_DEFEND);
+			}
+		}
+	}
+}
+
+inline void CONTROL_PANELS::mfHaltAllToDefend()
+{
+	// Halt = press Defend on the whole party at once.  First set every PC's
+	// current and last fighting style to defend.
+	mfSetAllDefend();
+
+	// Then force any actively engaged PC into AI_DEFEND.  The chase/attack states
+	// (AI_MOVING/AI_ATTACK/AI_FALLBACK) do not re-read the fighting style mid-action, and
+	// AI_SEARCH only honours it on its next decision, so without this a PC that was
+	// pursuing a target would keep chasing after Halt and only start defending once it
+	// dropped back to AI_SEARCH.  Forcing AI_DEFEND stops the pursuit immediately: the PC
+	// holds position and defends an adjacent enemy if one is in melee range.  States that
+	// must not be interrupted (casting, dead, stoned, paused, etc.) are left untouched.
+	for (LONG i = 0; i < MAX_NUMBER_CONTROLS; i++)
+	{
+		if (fccActive[i].fhAvatar != fERROR)
+		{
+			CAvatar * const pAvatar = (CAvatar * const) BLKPTR(fccActive[i].fhAvatar);
+			if (!pAvatar->mfAmIImmoblized())
+			{
+				switch (pAvatar->Status)
+				{
+				case CAvatar::AI_MOVING:
+				case CAvatar::AI_ATTACK:
+				case CAvatar::AI_SEARCH:
+				case CAvatar::AI_FALLBACK:
+					pAvatar->Status = CAvatar::AI_DEFEND;
+					break;
+				default:
+					break;
+				}
 			}
 		}
 	}

--- a/COMBDATA.HXX
+++ b/COMBDATA.HXX
@@ -39,6 +39,7 @@
 #define DEAD_TIMER_WAIT	100
 #define COMBAT_TIMES_OUT	100
 #define ABSOLUTE_RPG_WAIT	400
+#define RECENT_COMBAT_TICKS	50	// 5 seconds: combat auto-ends this long after the last combat event
 /* ------------------------------------------------------------------------
    Enums
    ------------------------------------------------------------------------ */
@@ -249,7 +250,7 @@ inline void COMBAT_SCENE_DATA::mfRestoreSceneVals()
 	
 inline void COMBAT_SCENE_DATA::mfInitCombatTimer()
 {
-	fCombatTimer = SCENE_MGR::gTick + COMBAT_TIMES_OUT;	// 10 seconds till time out.
+	fCombatTimer = SCENE_MGR::gTick + RECENT_COMBAT_TICKS;	// 5 seconds to auto-end.
 	fgTickPrev = SCENE_MGR::gTick;
 }
 

--- a/COMBOPTS.CPP
+++ b/COMBOPTS.CPP
@@ -86,8 +86,12 @@ void RECHECK_OPTIONS::mfUpDateOptions()
 	else
 	{
 		replace_key(GAME_KEYS::mfGetKey(GAME_KEYS::COMBAT_DEFEND), CombatDefendKey, 0, &oldKey);
-		
-		SetButtonLabel(D_COMBAT_RPGBOTTOM_BAR, BUTNO_RPG_DONE, STR_NULL, 0);
+
+		// Arcade mode reuses the RPG "Done" button as Halt (CombatTurnDoneKey
+		// dispatches to CombatHaltKey).  STR_ANIM_STOP is the nearest existing
+		// localized label - birthrt ships a prebuilt STRDAT.DAT, so no new
+		// string id can be added for "Halt".
+		SetButtonLabel(D_COMBAT_RPGBOTTOM_BAR, BUTNO_RPG_DONE, STR_ANIM_STOP, 223);
 	}
 	
 	CONTROL_PANELS::mfUpdateOptions();


### PR DESCRIPTION
…tus text, and a Halt button

Ported from birp-dev 62803ec.

Combat now auto-ends 5s after the last attack instead of 10s, the arcade bottom-bar button becomes Halt (sets the whole party to Defend and drops any chase straight into AI_DEFEND), and the panel status lines name the target instead of printing raw damage ranges.

Adapted for birthrt: the button is repointed by dispatching from CombatTurnDoneKey rather than birp's SetButtonProc, which only patches the menu table and not the already-registered region. birthrt ships a prebuilt STRDAT.DAT and STRMGR_InitStrMgr hard-fails when STR_MAX_STRINGS moves, so the 13 new string ids were not added; the new wording is literal in-code text and the button reuses the existing localized STR_ANIM_STOP label.

Left out: birp's logger calls, the per-panel Defend-button flash and the two panel-handle accessors that only served it, the stale fChaseStartTick reset (no such field here), and the arcade replace_key(COMBAT_DONE, CombatHaltKey) - COMBAT_DONE and COMBAT_DEFEND are both KEY_D, so it would have silently stolen the arcade Defend hotkey.