### PR TITLE
port(issue-30): stop units[-1] crashes at end of turn and in multiplayer

### DIFF
--- a/GAMEMAP.CPP
+++ b/GAMEMAP.CPP
@@ -4180,9 +4180,14 @@ void RandomEvents (void)
 				DoRandomEvent(random(8)+9, prov);	// random monster
 
 		// give 5-10/5-15/5-20 skeletons directly to the gorgon where ever he is
-		prov = (PROVINCE) units[regents[THE_GORGON].mfGetunit()].province;
-		for (i=random(rm)+5; i>=0; i--)
-			DoRandomEvent(12, prov);					// skeletons
+		// (he may be dead or unplaced, in which case he has no unit to find)
+		LONG const iGorgonUnit = regents[THE_GORGON].mfGetunit();
+		if (iGorgonUnit > 0 && iGorgonUnit < MAX_UNITS)
+		{
+			prov = (PROVINCE) units[iGorgonUnit].province;
+			for (i=random(rm)+5; i>=0; i--)
+				DoRandomEvent(12, prov);				// skeletons
+		}
 	}
 
 	// ------------------------------------------

--- a/MAPAI.CPP
+++ b/MAPAI.CPP
@@ -5041,30 +5041,39 @@ CreateHldng:
 					}
 					else		// non-landed vassal becomes lieutenant instead
 					{
-						TargetProvince = (PROVINCE)units[regents[realm[CurrentRealm].mfGetRegent()].mfGetunit()].province;
-						for (j=69; j<CHARACTER_COUNT; ++j)			// scan all regents
+						// the realm may be regentless, or its regent may have no unit
+						LONG const iCurrentRegent = realm[CurrentRealm].mfGetRegent();
+						LONG const iCurrentRegentUnit = (iCurrentRegent != NO_REGENT)
+							? regents[iCurrentRegent].mfGetunit()
+							: fERROR;
+
+						if (iCurrentRegentUnit > 0 && iCurrentRegentUnit < MAX_UNITS)
 						{
-							if (regents[j].mfGetRealm() == TargetRealm)
+							TargetProvince = (PROVINCE)units[iCurrentRegentUnit].province;
+							for (j=69; j<CHARACTER_COUNT; ++j)			// scan all regents
 							{
-								TargetPlace = j;
-							 	LONG const iUnit = CreateUnit(TargetProvince, regents[TargetPlace].mfGeticon(), (LONG) regents[TargetPlace].mfGetid(), CurrentRealm, FALSE);
-								if (iUnit != fERROR)
+								if (regents[j].mfGetRealm() == TargetRealm)
 								{
-									if (regents[TargetPlace].mfGetRealm() >= LAND_REALM_COUNT
-									   	|| regents[TargetPlace].mfGetRealm() == HomeRealm)
-										for (k=0; k<MAX_PLACES; ++k)
-										{
-											if(places[k].Realm == regents[TargetPlace].mfGetRealm())
+									TargetPlace = j;
+								 	LONG const iUnit = CreateUnit(TargetProvince, regents[TargetPlace].mfGeticon(), (LONG) regents[TargetPlace].mfGetid(), CurrentRealm, FALSE);
+									if (iUnit != fERROR)
+									{
+										if (regents[TargetPlace].mfGetRealm() >= LAND_REALM_COUNT
+										   	|| regents[TargetPlace].mfGetRealm() == HomeRealm)
+											for (k=0; k<MAX_PLACES; ++k)
 											{
-												CheckHolding(k, CurrentRealm, FALSE);
+												if(places[k].Realm == regents[TargetPlace].mfGetRealm())
+												{
+													CheckHolding(k, CurrentRealm, FALSE);
+												}
 											}
-										}
-									SetGameData(MP_REGENT, MPREG_UNIT, TargetPlace, iUnit, FALSE );
-									// HACK HACK HACK HACK HACK
-									// GWP Don't set this anymore. (It's read from the units array.
+										SetGameData(MP_REGENT, MPREG_UNIT, TargetPlace, iUnit, FALSE );
+										// HACK HACK HACK HACK HACK
+										// GWP Don't set this anymore. (It's read from the units array.
+									}
+									// even if we can't create a unit we have to stop.
+									break;
 								}
-								// even if we can't create a unit we have to stop.
-								break;
 							}
 						}
 					}

--- a/MULTIMAP.CPP
+++ b/MULTIMAP.CPP
@@ -483,6 +483,9 @@ void DoSetGameData(LONG lArray_Id, LONG lStruct_Id, LONG lArray_Index, LONG lDat
 			break;
 
 		case	MP_UNITS:
+			// a bad index here would scribble over memory outside the units array
+			if (lArray_Index < 0 || lArray_Index >= MAX_UNITS)
+				return;
 			switch(lStruct_Id)
 			{
 				case	MPUNITS_PROVINCE:
@@ -957,6 +960,9 @@ LONG DoGetGameData(LONG lArray_Id, LONG lStruct_Id, LONG lArray_Index)
 			break;
 
 		case	MP_UNITS:
+			// a bad index here would read memory outside the units array
+			if (lArray_Index < 0 || lArray_Index >= MAX_UNITS)
+				return fERROR;
 			switch(lStruct_Id)
 			{
 				case	MPUNITS_PROVINCE:


### PR DESCRIPTION
Ported from birp-dev 292c65f.

Guards the two places that dereference units[] with an unvalidated regent unit index (the Gorgon's per-turn skeleton grant in RandomEvents, and the non-landed-vassal-to-lieutenant conversion in DoNPCAction), plus the MP_UNITS index in DoSetGameData/DoGetGameData so a bad index from a peer can no longer read or write outside the units array.

birp-dev's logInfo/logError calls in each guard were dropped: birthrt has no LOGGER.CPP, and none of these states warrant a hard Fatal().