### PR TITLE
port(issue-33): assassination reports now name the unit type that was…

### DIFF
--- a/ACTNMENU.CPP
+++ b/ACTNMENU.CPP
@@ -4199,7 +4199,7 @@ spyexit:	;
 							
 							AddSndObj((BIRTHRT_SND)SND_UI_SUCCEEDED,0,VOLUME_NINETY);
 							if (whichProv > NO_PROVINCE && whichProv < NO_PROVINCE2)
-								SendReportTo(whichRealm, IMMEDIATE_NPC_ASSASSIN, HomeRealm, whichProv, 0);
+								SendReportTo(whichRealm, IMMEDIATE_NPC_ASSASSIN, HomeRealm, whichProv, units[iSelectedUnit].Icon);
 							SetScrewed(whichRealm, HomeRealm, TRUE );
 				  			DeleteUnit(iSelectedUnit, TRUE );
 						}

--- a/MAPAI.CPP
+++ b/MAPAI.CPP
@@ -5414,7 +5414,7 @@ CreateHldng:
 
 			npc_ai[rlm].CurrentAction = action;
 			if(units[TargetUnit].Realm == HomeRealm && TargetProvince > NO_PROVINCE && TargetProvince < NO_PROVINCE2)
-				AddReport(	IMMEDIATE_NPC_ASSASSIN, CurrentRealm, TargetProvince, 0);
+				AddReport(	IMMEDIATE_NPC_ASSASSIN, CurrentRealm, TargetProvince, units[TargetUnit].Icon);
 
 			SetScrewed((REALM::REALM_TYPE)units[TargetUnit].Realm, CurrentRealm, FALSE );
 			DeleteUnit(TargetUnit, FALSE );

--- a/REPORT.CPP
+++ b/REPORT.CPP
@@ -293,7 +293,7 @@ DEFINE_VECTOR_DATA(SUBJECT,Subject) = {
 /*SUBJ_NPC_BLIGHT*/    	    {WIZARD + 70, REALM_NAME, PROV_NAME,   NO_ARRAY,  {STR_RPT_NPC_BLIGHT,STR_RPT_NPC_BLIGHT,STR_NULL,STR_NULL,STR_NULL}},
 /*SUBJ_NPC_WARDING*/    	{WIZARD + 71, REALM_NAME, PROV_NAME,   NO_ARRAY,  {STR_RPT_NPC_WARDING,STR_RPT_NPC_WARDING,STR_NULL,STR_NULL,STR_NULL}},
 /*SUBJ_NPC_STRONGHOLD*/    	{WIZARD + 72, REALM_NAME, PROV_NAME,   NO_ARRAY,  {STR_RPT_NPC_STRONGHOLD,STR_RPT_NPC_STRONGHOLD,STR_NULL,STR_NULL,STR_NULL}},
-/*SUBJ_NPC_ASSASSIN*/       {GENERAL + 73, REALM_NAME, PROV_NAME, NO_ARRAY, {STR_RPT_NPC_ASSASSIN, STR_RPT_NPC_ASSASSIN, STR_NULL, STR_NULL, STR_NULL}},		
+/*SUBJ_NPC_ASSASSIN*/       {GENERAL + 73, REALM_NAME, PROV_NAME, UNIT_ICON, {STR_RPT_NPC_ASSASSIN, STR_RPT_NPC_ASSASSIN, STR_NULL, STR_NULL, STR_NULL}},
 /*SUBJ_NPC_CONTEST_DESTROY*/ {GENERAL + 74, REALM_NAME, HOLDING_TYP,PROV_NAME,  {STR_RPT_NPC_CONTEST_DESTROY, STR_RPT_NPC_CONTEST_DESTROY,STR_NULL, STR_NULL, STR_NULL}},
 /*SUBJ_ALLY_DECLARE_WAR*/	{GENERAL +  75, ALLY_LEVEL, REALM_NAME,   REALM_NAME,   {STR_RPT_ALLY_DECLARE_WAR,STR_RPT_ALLY_DECLARE_WAR,STR_NULL,STR_NULL,STR_NULL}},
 /*SUBJ_USED_FREEACTION*/	{CHAMBER +  76, NO_ARRAY, NO_ARRAY,   NO_ARRAY,   {STR_RPT_USED_FREEACTION,STR_NULL,STR_NULL,STR_NULL,STR_NULL}},
@@ -702,7 +702,18 @@ void CheckForImmediateReports(void)
 			strcpy(str0, STRMGR_GetStr(Subject[report[i].subject].sz[0]));
 
 			sprintf(n, str0, str1, str2, str3);
-		
+
+			// For SUBJ_NPC_ASSASSIN the runtime string data (strdat.dat) uses
+			// only two %s args (realm, province).  Append the unit type directly
+			// so the message is correct regardless of which strdat.dat is deployed.
+			if (report[i].subject == SUBJ_NPC_ASSASSIN && str3[0] != '\0')
+			{
+				size_t len = strlen(n);
+				if (len > 0 && n[len-1] == '.')
+					len--;
+				sprintf(n+len, ": %s.", str3);
+			}
+
 			// setup for generic statement box
 			SetButtonProc (D_QUESTION1, 0, PaintImmediateReport, 0, 0);
 			SetButtonLabel  (D_QUESTION1, QUESTION_TEXT, -1, BLACK );
@@ -889,6 +900,10 @@ static char const * const ReportString (LONG str_typ, LONG index)
 			if(index > MAX_UNITS)
 				index = 0;
 			return STRMGR_GetStr(gsUnitTitle[units[index].Icon]);
+		case UNIT_ICON:
+			if(index >= MAP_ICON_COUNT)
+				index = NO_MAP_ICON;
+			return STRMGR_GetStr(gsUnitTitle[index]);
 		case ALLY_LEVEL:
 			if(index > 4)
 				index = 0;

--- a/REPORT.HXX
+++ b/REPORT.HXX
@@ -40,6 +40,7 @@
 #define LOY_LEVEL		9
 #define UNIT_TITLE		10
 #define ALLY_LEVEL		11
+#define UNIT_ICON		12
 #define IMMEDIATE	1024
 
 /* ------------------------------------------------------------------------


### PR DESCRIPTION
… killed

Ported from birp-dev 8df948d.

Both call sites (player-initiated assassination in ACTNMENU.CPP and the NPC AI action in MAPAI.CPP) now pass the victim's map icon as index3 instead of 0, and REPORT.CPP resolves it through a new UNIT_ICON string type. Because the shipped strdat.dat STR_RPT_NPC_ASSASSIN format only has two %s slots, the unit type is also appended directly in CheckForImmediateReports, matching birp-dev.

Left out: the DEBUG-only F11 realm-mode assassination trigger (GAMEMAP.CPP/GAMEMAP.HXX/MAIN.CPP) - a test hook, not gameplay - and all logInfo/logWarn calls, since birthrt has no logger.