### PR TITLE
port(issue-35): restore adventure music after the quest item popup

### DIFF
--- a/GAME.CPP
+++ b/GAME.CPP
@@ -98,6 +98,7 @@ void BeginRule(LONG, LONG);
 void DoneHelpKeys(LONG, LONG);
 void PaintQuestItemFound(LONG,LONG);
 void QuestItemFoundProc(LONG,LONG);
+void ShowQuestItemVictoryScreen(void);
 void Sinners(LONG, LONG);
 BOOL BattlePrep(void);
 
@@ -2102,7 +2103,7 @@ int PaintInputField(LONG lButtonId, char *szBuffer, LONG lBufLen, LONG lFont,
 					)
 				{
 					InputHideMenu();
-					VictoryScreen(PaintQuestItemFound,QuestItemFoundProc);
+					ShowQuestItemVictoryScreen();
 					return 2;
 				}
 				//activates the specified item

--- a/INVNTORY.CPP
+++ b/INVNTORY.CPP
@@ -106,6 +106,11 @@ extern SHORT BARelicFound;			// from practice.cpp
 
 extern void VictoryScreen(PFVLL,PFVLL);
 
+// VictoryScreen() suspends the music and forces ucWhichTrack to REDBOOK_REALM,
+// so the quest item popup has to remember what the scene was playing.
+static SHORT gQuestItemPrevTrack = fERROR;
+static BOOL gQuestItemTrackRestorePending = FALSE;
+
 extern BOOL fStartMultiGame;
 
 /* ========================================================================
@@ -184,6 +189,32 @@ void QuestItemFoundProc(LONG MenuCombo,LONG b)
 	TickDelay(4);
 	HideMenu(MenuId);
 	RunMenus();
+
+	if (gQuestItemTrackRestorePending)
+	{
+		if (master_game_type == GAME_ADVENTURE)
+		{
+			// 100 is the "no music" sentinel, so fall back to the combat track.
+			SHORT const ResumeTrack =
+				(gQuestItemPrevTrack == fERROR || gQuestItemPrevTrack == 100)
+					? (SHORT)REDBOOK_PERSCOMBAT
+					: gQuestItemPrevTrack;
+
+			ucWhichTrack = ResumeTrack;
+			ResumeSuspendedMusic();
+			PlayTrack(ResumeTrack);
+		}
+
+		gQuestItemTrackRestorePending = FALSE;
+		gQuestItemPrevTrack = fERROR;
+	}
+}
+
+void ShowQuestItemVictoryScreen(void)
+{
+	gQuestItemPrevTrack = ucWhichTrack;
+	gQuestItemTrackRestorePending = TRUE;
+	VictoryScreen(PaintQuestItemFound,QuestItemFoundProc);
 }
 
 LONG GetLevelFiendIndex(void)
@@ -378,7 +409,7 @@ void ObjectList::mfMouseCallback(LONG but,LONG obj,LONG /* WadThingtype */)
 				else
 #endif
 				{
-					VictoryScreen(PaintQuestItemFound,QuestItemFoundProc);
+					ShowQuestItemVictoryScreen();
 				}
 
 				RunMenus();

--- a/REDBOOK.C
+++ b/REDBOOK.C
@@ -75,6 +75,7 @@ int fMusic = 1;
 static int CurrentSong = fERROR;
 static int CurrentTag = fERROR;
 static BOOL MusicSuspended = FALSE;
+static SHORT PendingTrack = fERROR;
 SHORT UserCDVolume = 100;
 
 SHORT ucWhichTrack = 0;
@@ -246,10 +247,21 @@ int PlayTrack (SHORT track)
 {
 	
 	if(!fMusic || MusicSuspended)
+	{
+		// Remember what was asked for while suspended so the track isn't
+		// lost - ResumeSuspendedMusic() starts it.
+		if(MusicSuspended && fMusic)
+		{
+			PendingTrack = track;
+			ucWhichTrack = track;
+		}
 		return 0;
-		
+	}
+
+	PendingTrack = fERROR;
+
 	ucWhichTrack = track;
-	
+
 	if(CurrentTag != fERROR)
 			StopASound(CurrentSong,CurrentTag);
 
@@ -623,6 +635,12 @@ void SuspendMusic(void)
 void ResumeSuspendedMusic(void)
 {
 	MusicSuspended = FALSE;
+	if(fMusic && PendingTrack != fERROR)
+	{
+		SHORT DeferredTrack = PendingTrack;
+		PendingTrack = fERROR;
+		PlayTrack(DeferredTrack);
+	}
 }
 
 int GetMusicVolume(void)

--- a/SCNMGR.CPP
+++ b/SCNMGR.CPP
@@ -584,6 +584,8 @@ void SCENE_MGR::mfReleaseSceneToMap(LONG,LONG)
 	// return to the map
 	InitDomainTurn(0);
 	ResumeSuspendedMusic();
+	ucWhichTrack = REDBOOK_REALM;
+	PlayTrack(REDBOOK_REALM);
 }
 
 /* ========================================================================

--- a/SOUND.CPP
+++ b/SOUND.CPP
@@ -484,6 +484,19 @@ LONG AddLoopingSound(BIRTHRT_SND WaveID, LONG ThingIndex)
 {
 	LONG total;
 
+	// Anything but the -2 "full volume" marker has to be a live thing.
+	// A bad index would be read out of bounds by UpdateLoopingSoundObjects,
+	// and fERROR (-1) would be stored as the array's end marker and hide
+	// every sound added after it.
+	if(ThingIndex != -2)
+	{
+		if(ThingIndex < 0 || ThingIndex >= MAX_THINGS)
+			return fERROR;
+
+		if(mythings[ThingIndex].valid != TRUE)
+			return fERROR;
+	}
+
 	if(TotalLoopingSounds + 1 <= MAX_SOUND_THINGS)
 	{
 		LoopingSoundThing[TotalLoopingSounds].wave = WaveID;


### PR DESCRIPTION
Ported from birp-dev a74a95f.

VictoryScreen() suspends music and overwrites ucWhichTrack, so finding the quest item left the rest of the adventure silent. Both quest-item call sites (inventory pickup and the SYNGQI debug command) now go through ShowQuestItemVictoryScreen(), which remembers the scene track and restores it when the popup closes; PlayTrack() defers requests made while suspended and ResumeSuspendedMusic() replays them, and releasing a scene to the map restarts the realm track explicitly.

Adapted for birthrt: birp-dev logger calls dropped (no logger here), and the redundant REDBOOK.H include is omitted since SYSTEM.H already pulls it in. Left out birp-dev's DisableSfxWave blacklist - birthrt's KernelAudio::AudioPlay also returns 0 for the transient all-channels-busy case, so it would permanently mute an ambient/lava wave after one incidental failure. The AddLoopingSound index guard is kept: it stops out-of-range mythings[] reads and the fERROR entry that silently truncated the looping-sound list.