### PR TITLE
port(issue-52): stop crashes when moving between maps in the same adv…

### DIFF
--- a/COMBATUI.CPP
+++ b/COMBATUI.CPP
@@ -1449,7 +1449,13 @@ void ReleaseCombatUI(SCENE &rScene)
 		if (rScene.Avatars[i] != fERROR)
 		{
 			CAvatar * const pAvatar = (CAvatar * const) BLKPTR(rScene.Avatars[i]);
-			
+
+			// Don't touch an avatar whose block is already gone.
+			if (pAvatar == NULL)
+			{
+				continue;
+			}
+
 			// Clear the Pause mode (if set)
 			pAvatar->DoAI(CAvatar::AI_END_PAUSE);
 			

--- a/COMBCNTL.CPP
+++ b/COMBCNTL.CPP
@@ -718,7 +718,14 @@ void CONTROL_PANELS::CURRENT_CONTROL::mfSetBeginCombat(BOOL const AutoAttack)
 	{
 		LONG i;
 		CAvatar * const pAvatar = (CAvatar * const) BLKPTR(fhAvatar);
-		
+
+		// The panel caches its avatar across scenes; drop it if it's stale.
+		if (pAvatar == NULL)
+		{
+			fhAvatar = fERROR;
+			return;
+		}
+
 		fOriginalAngle = pAvatar->mfAngle();
 		fOriginalStatus = pAvatar->Status;
 		fOriginalLeftButtonFn = pAvatar->mfSetLeftButtonFn(CombatSelectThisAdventurer);
@@ -791,7 +798,12 @@ BOOL const CONTROL_PANELS::CURRENT_CONTROL::mfNeedToUpdatePanel()
 	if (fhAvatar != fERROR)
 	{
 		CAvatar const * const pAvatar = (CAvatar *const) BLKPTR(fhAvatar);
-		
+
+		if (pAvatar == NULL)
+		{
+			return FALSE;
+		}
+
 		if (pAvatar->Status != fPrevStatus)
 		{
 			fPrevStatus = pAvatar->Status;

--- a/SCENE.CPP
+++ b/SCENE.CPP
@@ -171,6 +171,9 @@ void SCENE::mfLoadScene(char * cpSceneFile,
 // after the load is complete.)
 	SysHideCursor ();
 #endif
+	// Drop the previous scene's ambient profile. If the new scene has no
+	// [AmbientSound] section we would otherwise keep playing the old one.
+	ResetEnvironmentalSoundState();
 	// Re-initialize the internal variables.
 	StopRedBook();
 	TurnOffAllSounds();
@@ -707,7 +710,6 @@ LONG SCENE::mfReadAvatars(FILE *fp)
 						// GWP We call this instead of DeleteAvatar for Debug purposes
 						DisposBlock(Avatars[i]);
 						Avatars[i] = fERROR;
-						i--;
 						continue;
 					}
 					
@@ -1617,7 +1619,7 @@ void SCENE::mfAttachAutoAIsAndThingSnds ( void )
 				// Find the first available Avatar slot.
 				// Note: Since I don't reset i, we start looking from the
 				//       last open spot we found.
-				for (; Avatars[i] != fERROR && i < MAX_AVATARS;i++)
+				for (; i < MAX_AVATARS && Avatars[i] != fERROR;i++)
 				{};
 				
 				if (i >= MAX_AVATARS)
@@ -1643,7 +1645,6 @@ void SCENE::mfAttachAutoAIsAndThingSnds ( void )
 						printf("WARNING! Unable to load Avatar %d\n", ttype);
 						pAvatar->DeleteAvatar(pAvatar->hThis);
 						Avatars[i] = fERROR;
-						i--;
 						continue;
 					}
 					pAvatar->attrib.RuntimeCreated = TRUE;	// Don't save!

--- a/SCNAI.CPP
+++ b/SCNAI.CPP
@@ -620,6 +620,35 @@ void SCENE_AI::mfAdventureInit ( SCENE &rScene)
    ======================================================================== */
 void SCENE_AI::mfAdventureRelease (SCENE &rScene)
 {
+	ResetEnvironmentalSoundState();
+
+	// Drop every combat reference before the avatar blocks are freed. The
+	// party avatars survive a move to another map in the same adventure, so
+	// a handle left in hEnemy would point at an enemy from the old map.
+	for (LONG avi = 0; avi < MAX_AVATARS; avi++)
+	{
+		if (rScene.Avatars[avi] != fERROR)
+		{
+			CAvatar * const pAvatar = (CAvatar * const) BLKPTR(rScene.Avatars[avi]);
+			if (pAvatar == NULL)
+			{
+				continue;
+			}
+
+			if (pAvatar->hEnemy != fERROR)
+			{
+				pAvatar->mfSethEnemy(fERROR);
+			}
+
+			// Don't carry an in-progress attack into the next scene.
+			if (pAvatar->Status == CAvatar::AI_ATTACK ||
+				pAvatar->Status == CAvatar::AI_CASTSPELL)
+			{
+				pAvatar->Status = CAvatar::AI_INIT;
+			}
+		}
+	}
+
 	AdventureFixUnitsArray(SCENE_MGR::HomeIndex);
 	
 	// GWP We'll disconnect these player stats when we delete the avatars.

--- a/SCNMGR.CPP
+++ b/SCNMGR.CPP
@@ -551,7 +551,7 @@ Error:
 void SCENE_MGR::mfReleaseSceneToMap(LONG,LONG)
 {
 
-	PlayEnvironmentalSounds = FALSE;
+	ResetEnvironmentalSoundState();
 	SuspendMusic();
 	if (hCurrentScene != fERROR)
 	{

--- a/SOUND.CPP
+++ b/SOUND.CPP
@@ -114,6 +114,7 @@ static BOOL PauseAllSounds_Hits = 0;
 static BOOL AudioInitialized = FALSE;
 static LONG TotalEnvironSnds = 0;
 static LONG TotalLoopingSounds = 0;
+static SHORT FramesTilNextSound = 300;
 
 #define FADE_TO_RESET_COUNT 20;
 static LONG SoundFade = 0;
@@ -611,12 +612,22 @@ void InitSoundThings(void)
 }
 
 /*************************************************************************
+Function ResetEnvironmentalSoundState
+Purpose  clear the ambient sound selectors and timer between levels
+**************************************************************************/
+void ResetEnvironmentalSoundState(void)
+{
+	PlayEnvironmentalSounds = FALSE;
+	WhichEnvironmentalSound = 0;
+	FramesTilNextSound = 300;
+}
+
+/*************************************************************************
 Function ServiceDosAudio
 Purpose  prevent breakup up sound in DOS
 **************************************************************************/
 void ServiceSOLAudio(void)
 {
-	static SHORT FramesTilNextSound = 300;
 	if(!AudioInitialized )
 		return;
 

--- a/SOUND.HXX
+++ b/SOUND.HXX
@@ -174,6 +174,7 @@ void ShutDownSoundSystem(void);
 void TurnOffAllSounds(void);
 void KillSoundsNoFade(void);
 void	StopASound (int reqSound, int SoundTag);
+void ResetEnvironmentalSoundState(void);
 
 void ServiceSOLAudio(void);
 


### PR DESCRIPTION
…enture

Ported from birp-dev 51b598c.

Real fixes carried over: the two `i--` underflows and the reversed bounds test in SCENE::mfReadAvatars / mfAttachAutoAIsAndThingSnds (both index Avatars[-1] or Avatars[MAX_AVATARS] on a failed avatar load), clearing every avatar's hEnemy and in-progress attack status in mfAdventureRelease before the scene's avatar blocks are freed (party avatars outlive the scene, so the handle pointed at an enemy from the old map), a new ResetEnvironmentalSoundState() so a scene without an [AmbientSound] section no longer inherits the previous map's ambient profile, and the stale-handle guards in ReleaseCombatUI / mfSetBeginCombat / mfNeedToUpdatePanel.

Left out: all of birp-dev's logDebug/logInfo/logWarn scaffolding (birthrt has no logger), the whole MEMMANAG diagnostic dump, the ambient switch `default:` case (birthrt's switch calls AddSndObj per case, so an out-of-range profile already plays nothing), and the ResetEnvironmentalSoundState() call in InitCombatUI - zeroing WhichEnvironmentalSound there is never restored by mfRestoreSceneVals, which would silence a map's ambience after any combat.